### PR TITLE
Small addtion to the Octavia Butler example

### DIFF
--- a/examples/css/writingmode-article.css
+++ b/examples/css/writingmode-article.css
@@ -3,6 +3,8 @@ h2 {
       -ms-writing-mode: tb-rl;
           writing-mode: vertical-rl;
   float: left;
+  position: sticky;
+  top: 0;
   margin: 1.5rem 0 0 -3.8rem;
   font-size: 1.8em;
   background: #96e5fb;

--- a/examples/css/writingmode-article.css
+++ b/examples/css/writingmode-article.css
@@ -10,6 +10,13 @@ h2 {
   background: #96e5fb;
   padding: 8px 0; }
 
+h2 a {
+  color: inherit;
+  text-decoration: none; }
+
+h2 a:hover {
+  text-decoration: underline; }
+
 main {
   width: 80%;
   max-width: 52ch;

--- a/examples/writingmode-article.html
+++ b/examples/writingmode-article.html
@@ -14,8 +14,8 @@
     <h1>Octavia Butler</h1>
     <p><a href="http://octaviabutler.org">Octavia Estelle Butler</a> (June 22, 1947 – February 24, 2006) was an American science fiction writer. A multiple recipient of both the Hugo and Nebula awards, Butler was one of the best-known women in the field. In 1995, she became the first science fiction writer to receive the MacArthur Fellowship, nicknamed the "Genius Grant".</p>
     
-    <section>
-    <h2>Rise To Success</h2>
+    <section id="rise">
+    <h2><a href="#rise">Rise To Success</a></h2>
     <p>Even though Butler's mother wanted her to become a secretary with a steady income, Butler continued to work at a series of temporary jobs, preferring the kind of mindless work that would allow her to get up at two or three in the morning to write. Success continued to elude her, as an absence of useful criticism led her to style her stories after the white-and-male-dominated science fiction she had grown up reading. She enrolled at California State University, Los Angeles, but then switched to taking writing courses through UCLA Extension.</p>
   
     <p>Butler finally caught her break during the Open Door Workshop of the Screenwriters' Guild of America, West, a program designed to mentor minority writers. Her writing impressed one of the Writers Guild teachers, noted science-fiction writer Harlan Ellison, who encouraged her to attend the six-week Clarion Science Fiction Writers Workshop in Clarion, Pennsylvania. There, Butler met the writer and later longtime friend Samuel R. Delany. She also sold her two first stories: "Child Finder" to Ellison, for his anthology The Last Dangerous Visions (controversially, still unpublished), and "Crossover" to Robin Scott Wilson, the director of Clarion, who published it as part of the 1971 Clarion anthology.</p>
@@ -31,30 +31,30 @@
     <p>Octavia E. Butler, reading the self-penned description of herself included in Parable of the Sower during a 1994 interview with Jelani Cobb. In 1999, after her mother's death, Butler moved to Lake Forest Park, Washington. The Parable of the Talents had won the Science Fiction Writers of America's Nebula Award for Best Science Novel and she had plans for four more Parable novels: Parable of the Trickster, Parable of the Teacher, Parable of Chaos, and Parable of Clay. However, after several failed attempts to begin The Parable of the Trickster, she decided to stop work in the series. In later interviews, Butler explained that the research and writing of the Parable novels had overwhelmed and depressed her, so she had shifted to composing something "lightweight" and "fun" instead. This became her last book, the science-fiction vampire novel Fledgling (2005).</p>
     </section>
 
-    <section>
-    <h2>Influence</h2>
+    <section id="influence">
+    <h2><a href="#influence">Influence</a></h2>
     <p>In interviews with Charles Rowell and Randall Kenan, Butler credited the struggles of her working-class mother as an important influence on her writing. Because Butler's mother received little formal education herself, she made sure that young Butler was given the opportunity to learn by bringing her reading materials that her white employers threw away, from magazines to advanced books. She also encouraged Butler to write. She bought her daughter her first typewriter when she was ten years old, and, seeing her hard at work on a story, casually remarked that maybe one day she could become a writer, causing Butler to realize that it was possible to make a living as an author. A decade later, Mrs. Butler would pay more than a month's rent to have an agent review her daughter's work. She also provided Butler with the money she had been saving for dental work to pay for Butler's scholarship so she could attend the Clarion Science Fiction Writers Workshop, where Butler sold her first two stories.</p>
   
     <p>A second person to play an influential role in Butler's work was American writer Harlan Ellison. As a teacher at the Open Door Workshop of the Screen Writers Guild of America, he gave Butler her first honest and constructive criticism on her writing after years of lukewarm responses from composition teachers and baffling rejections from publishers. Impressed by her work, Ellison suggested she attend the Clarion Science Fiction Writers Workshop, and even contributed $100 towards her application fee. As the years passed, Ellison's mentorship became a close friendship.</p>
     </section>
 
-    <section>
-    <h2>Point of view</h2>
+    <section id="pov">
+    <h2><a href="#pov">Point of view</a></h2>
     
     <p>Butler began reading science fiction at a young age, but quickly became disenchanted by the genre's unimaginative portrayal of ethnicity and class as well as by its lack of noteworthy female protagonists. She then set to correct those gaps by, as De Witt Douglas Kilgore and Ranu Samantrai point out, "choosing to write self-consciously as an African-American woman marked by a particular history" — what Butler termed as "writing myself in". Butler's stories, therefore, are usually written from the perspective of a marginalized black woman whose difference from the dominant agents increases her potential for reconfiguring the future of her society.</p>
   
     <p><img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/OctaviaButler.jpg" alt="a photo of Octavia Butler"></p>
     </section>
 
-    <section>
-    <h2>Audience</h2>
+    <section id="audience">
+    <h2><a href="#audience">Audience</a></h2>
     <p>Publishers and critics have tended to label Butler's work as science fiction, but while Butler enjoyed working in what she called "potentially the freest genre in existence", she resisted being branded a genre writer. As many critics have pointed out, her narratives have drawn attention of people from varied ethnic and cultural backgrounds, and she herself claimed to have three loyal audiences: black readers, science-fiction fans, and feminists.</p>
     
     <p><img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/Butler_books.jpg" alt="book covers of Octavia Butler books" /></p>
     </section>
 
-    <section>
-    <h2>Interviews</h2>
+    <section id="interviews">
+    <h2><a href="#interviews">Interviews</a></h2>
       <p><a href="https://www.youtube.com/watch?v=66pu-Miq4tk">Charlie Rose interviewed Octavia Butler</a> in 2000 soon after the award of a MacArthur Fellowship. The highlights are probing questions that arise out of Butler's personal life narrative and her interest in becoming not only a writer, but a writer of science fiction. Rose asked, "What then is central to what you want to say about race?" Butler's response was, "Do I want to say something central about race? Aside from, 'Hey we're here!'?" This points to an essential claim for Butler that the world of science fiction is a world of possibilities, and although race is an innate element, it is embedded in the narrative, not forced upon it.</p>
     
     <p>In an interview by Randall Kenan, Octavia E. Butler discusses how her life experiences as a child shaped most of her thinking. As a writer, Butler was able to use her writing as a vehicle to critique history under the lenses of feminism. In the interview, she discusses the research that had to be done in order to write her bestselling novel, Kindred. Most of it is based on visiting libraries as well as historic landmarks with respect to what she is investigating. Butler admits that she writes science fiction because she does not want her work to be labeled or used as a marketing tool. She wants the readers to be genuinely interested in her work and the story she provides, but at the same time she fears that people will not read her work because of the "science fiction" label that they have.</p>

--- a/examples/writingmode-article.html
+++ b/examples/writingmode-article.html
@@ -14,6 +14,7 @@
     <h1>Octavia Butler</h1>
     <p><a href="http://octaviabutler.org">Octavia Estelle Butler</a> (June 22, 1947 – February 24, 2006) was an American science fiction writer. A multiple recipient of both the Hugo and Nebula awards, Butler was one of the best-known women in the field. In 1995, she became the first science fiction writer to receive the MacArthur Fellowship, nicknamed the "Genius Grant".</p>
     
+    <section>
     <h2>Rise To Success</h2>
     <p>Even though Butler's mother wanted her to become a secretary with a steady income, Butler continued to work at a series of temporary jobs, preferring the kind of mindless work that would allow her to get up at two or three in the morning to write. Success continued to elude her, as an absence of useful criticism led her to style her stories after the white-and-male-dominated science fiction she had grown up reading. She enrolled at California State University, Los Angeles, but then switched to taking writing courses through UCLA Extension.</p>
   
@@ -28,29 +29,38 @@
     <p>"Who am I? I am a forty-seven-year-old writer who can remember being a ten-year-old writer and who expects someday to be an eighty-year-old writer. I am also comfortably asocial—a hermit.... A pessimist if I'm not careful, a feminist, a Black, a former Baptist, an oil-and-water combination of ambition, laziness, insecurity, certainty, and drive."</p>
   
     <p>Octavia E. Butler, reading the self-penned description of herself included in Parable of the Sower during a 1994 interview with Jelani Cobb. In 1999, after her mother's death, Butler moved to Lake Forest Park, Washington. The Parable of the Talents had won the Science Fiction Writers of America's Nebula Award for Best Science Novel and she had plans for four more Parable novels: Parable of the Trickster, Parable of the Teacher, Parable of Chaos, and Parable of Clay. However, after several failed attempts to begin The Parable of the Trickster, she decided to stop work in the series. In later interviews, Butler explained that the research and writing of the Parable novels had overwhelmed and depressed her, so she had shifted to composing something "lightweight" and "fun" instead. This became her last book, the science-fiction vampire novel Fledgling (2005).</p>
-    
+    </section>
+
+    <section>
     <h2>Influence</h2>
     <p>In interviews with Charles Rowell and Randall Kenan, Butler credited the struggles of her working-class mother as an important influence on her writing. Because Butler's mother received little formal education herself, she made sure that young Butler was given the opportunity to learn by bringing her reading materials that her white employers threw away, from magazines to advanced books. She also encouraged Butler to write. She bought her daughter her first typewriter when she was ten years old, and, seeing her hard at work on a story, casually remarked that maybe one day she could become a writer, causing Butler to realize that it was possible to make a living as an author. A decade later, Mrs. Butler would pay more than a month's rent to have an agent review her daughter's work. She also provided Butler with the money she had been saving for dental work to pay for Butler's scholarship so she could attend the Clarion Science Fiction Writers Workshop, where Butler sold her first two stories.</p>
   
     <p>A second person to play an influential role in Butler's work was American writer Harlan Ellison. As a teacher at the Open Door Workshop of the Screen Writers Guild of America, he gave Butler her first honest and constructive criticism on her writing after years of lukewarm responses from composition teachers and baffling rejections from publishers. Impressed by her work, Ellison suggested she attend the Clarion Science Fiction Writers Workshop, and even contributed $100 towards her application fee. As the years passed, Ellison's mentorship became a close friendship.</p>
-  
+    </section>
+
+    <section>
     <h2>Point of view</h2>
     
     <p>Butler began reading science fiction at a young age, but quickly became disenchanted by the genre's unimaginative portrayal of ethnicity and class as well as by its lack of noteworthy female protagonists. She then set to correct those gaps by, as De Witt Douglas Kilgore and Ranu Samantrai point out, "choosing to write self-consciously as an African-American woman marked by a particular history" — what Butler termed as "writing myself in". Butler's stories, therefore, are usually written from the perspective of a marginalized black woman whose difference from the dominant agents increases her potential for reconfiguring the future of her society.</p>
   
     <p><img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/OctaviaButler.jpg" alt="a photo of Octavia Butler"></p>
-  
+    </section>
+
+    <section>
     <h2>Audience</h2>
     <p>Publishers and critics have tended to label Butler's work as science fiction, but while Butler enjoyed working in what she called "potentially the freest genre in existence", she resisted being branded a genre writer. As many critics have pointed out, her narratives have drawn attention of people from varied ethnic and cultural backgrounds, and she herself claimed to have three loyal audiences: black readers, science-fiction fans, and feminists.</p>
     
     <p><img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/Butler_books.jpg" alt="book covers of Octavia Butler books" /></p>
-    
+    </section>
+
+    <section>
     <h2>Interviews</h2>
       <p><a href="https://www.youtube.com/watch?v=66pu-Miq4tk">Charlie Rose interviewed Octavia Butler</a> in 2000 soon after the award of a MacArthur Fellowship. The highlights are probing questions that arise out of Butler's personal life narrative and her interest in becoming not only a writer, but a writer of science fiction. Rose asked, "What then is central to what you want to say about race?" Butler's response was, "Do I want to say something central about race? Aside from, 'Hey we're here!'?" This points to an essential claim for Butler that the world of science fiction is a world of possibilities, and although race is an innate element, it is embedded in the narrative, not forced upon it.</p>
     
     <p>In an interview by Randall Kenan, Octavia E. Butler discusses how her life experiences as a child shaped most of her thinking. As a writer, Butler was able to use her writing as a vehicle to critique history under the lenses of feminism. In the interview, she discusses the research that had to be done in order to write her bestselling novel, Kindred. Most of it is based on visiting libraries as well as historic landmarks with respect to what she is investigating. Butler admits that she writes science fiction because she does not want her work to be labeled or used as a marketing tool. She wants the readers to be genuinely interested in her work and the story she provides, but at the same time she fears that people will not read her work because of the "science fiction" label that they have.</p>
     
     <p>More at <a href="https://en.wikipedia.org/wiki/Octavia_E._Butler">Wikipedia</a>.</p>
+    </section>
   </main>
 
   </body>


### PR DESCRIPTION
Since the h2 headings are vertical and on the side, you can add position sticky to them to keep them visible as long as you read the section, without consuming any extra space or overlapping with anything. I find that a helpful hint of where you are in the document, similar to running headers and footers in paged media. This [doesn't work in every browser yet](http://caniuse.com/#feat=css-sticky), but it doesn't cause any issue in the browsers where it doesn't.

While I'm at it, I also added links from these headers to the top of the section they're heading, for convenient bookmarking.

Try it here: https://rawgit.com/frivoal/labs.jensimmons.com/Octavia-sticky/examples/writingmode-article.html

Maybe you'll find that I have terrible taste and that this too tacky, but I like it.